### PR TITLE
Added npm start and forever as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
   },
   "engines": {
     "node": "0.10.x"
+  },
+  "devDependencies": {
+    "forever": "0.15.1"
+  },
+  "scripts": {
+    "start": "forever start -c coffee --uid hubot node_modules/.bin/hubot -a slack",
+    "stop": "forever stop hubot"
   }
 }


### PR DESCRIPTION
I did a little more work than I thought I was going to have to but here goes.
### To setup after merging:

Add the `HUBOT_SLACK_TOKEN` as an environment variable. If we're still on Heroku then this should be automatic, if we're on AWS or DO or something, just ssh in and add the variable.

`npm install`

Will install the new `devDependencies` which in this case is just `forever`, thought about putting `coffee` in here but it's a hubot dependency so whatever really.

`npm start`
Will start the hubot as a forever service named hubot

`npm restart` 
Will restart hubot, just runs stop then start

`npm stop`
Will stop the forever process
